### PR TITLE
Default tasks to not using multimask

### DIFF
--- a/pet/pvp.py
+++ b/pet/pvp.py
@@ -56,7 +56,9 @@ class PVP(ABC):
         if verbalizer_file:
             self.verbalize = PVP._load_verbalizer_from_file(verbalizer_file, self.pattern_id)
 
-        use_multimask = issubclass(TASK_HELPERS[self.wrapper.config.task_name], MultiMaskTaskHelper)
+        use_multimask = (self.wrapper.config.task_name in TASK_HELPERS) and (
+            issubclass(TASK_HELPERS[self.wrapper.config.task_name], MultiMaskTaskHelper)
+        )
         if not use_multimask and self.wrapper.config.wrapper_type in [wrp.MLM_WRAPPER, wrp.PLM_WRAPPER]:
             self.mlm_logits_to_cls_logits_tensor = self._build_mlm_logits_to_cls_logits_tensor()
 


### PR DESCRIPTION
Since `TASK_HELPERS` doesn't contain a key for every possible task (e.g., `mnli`), trying to run `mnli` on master causes a crash (below). This PR sets `use_multimask` to false in the event that a task does not have a registered task helper.

```
Traceback (most recent call last):
  File "cli.py", line 282, in <module>
    main()
  File "cli.py", line 258, in main
    pet.train_pet(pet_model_cfg, pet_train_cfg, pet_eval_cfg, sc_model_cfg, sc_train_cfg, sc_eval_cfg,
  File "/home/nfliu/git/pet/pet/modeling.py", line 246, in train_pet
    train_pet_ensemble(ensemble_model_config, ensemble_train_config, ensemble_eval_config, pattern_ids, output_dir,
  File "/home/nfliu/git/pet/pet/modeling.py", line 341, in train_pet_ensemble
    wrapper = init_model(model_config)
  File "/home/nfliu/git/pet/pet/modeling.py", line 146, in init_model
    model = TransformerModelWrapper(config)
  File "/home/nfliu/git/pet/pet/wrapper.py", line 159, in __init__
    self.preprocessor = PREPROCESSORS[self.config.wrapper_type](self, self.config.task_name, self.config.pattern_id,
  File "/home/nfliu/git/pet/pet/preprocessor.py", line 38, in __init__
    self.pvp = PVPS[task_name](self.wrapper, pattern_id, verbalizer_file)  # type: PVP
  File "/home/nfliu/git/pet/pet/pvp.py", line 59, in __init__
    use_multimask = issubclass(TASK_HELPERS[self.wrapper.config.task_name], MultiMaskTaskHelper)
KeyError: 'mnli'
```