### PR TITLE
Fix gradient accumulation with small dataset sizes

### DIFF
--- a/pet/wrapper.py
+++ b/pet/wrapper.py
@@ -265,6 +265,7 @@ class TransformerModelWrapper:
         if n_gpu > 1:
             self.model = torch.nn.DataParallel(self.model)
 
+        step = 0
         global_step = 0
         tr_loss, logging_loss = 0.0, 0.0
         self.model.zero_grad()
@@ -273,7 +274,7 @@ class TransformerModelWrapper:
 
         for _ in train_iterator:
             epoch_iterator = tqdm(train_dataloader, desc="Iteration")
-            for step, batch in enumerate(epoch_iterator):
+            for _, batch in enumerate(epoch_iterator):
                 self.model.train()
                 unlabeled_batch = None
 
@@ -328,6 +329,7 @@ class TransformerModelWrapper:
                 if 0 < max_steps < global_step:
                     epoch_iterator.close()
                     break
+                step += 1
             if 0 < max_steps < global_step:
                 train_iterator.close()
                 break


### PR DESCRIPTION
Right now, `step` is reset across epochs. This is problematic if, say, you're training on a dataset with 8 examples but have a per-gpu batch size of 8 and want to do gradient accumulation for 4 steps. You'll never reach `step = 4`, and then never do gradient updates.

this fix just persists `step` across epochs